### PR TITLE
Add new libraries on virtual machines: pkg-config and jemalloc

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,7 +4,9 @@ LABEL maintainer="renbou"
 
 # Install all required tools
 RUN apt update && \
-    apt install -y clang-tidy-10 clang-11 clang-format cmake
+    apt install -y clang-tidy-10 clang-11 clang-format cmake && \
+    apt install -y pkg-config &&\
+    apt install -y libjemalloc-dev
 
 # Make clang the default compiler, make clang-tidy link
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-11 60 && \


### PR DESCRIPTION
В 4  дз на кэш и алокатор в тестах присутствует библиотека jemalloc и pkg-config для её подключения в Cmake. Однако в самом локальном окружении они не установлены. Поэтому и был написан этот фикс.
Отчёт о проверке работоспособности.

Проверены системы
1. Windows
2. Linux (ubuntu, manjaro)
3. MacOS

Проверены модификации дз

hw 1 calc
1.calc-fac-log
2.calc-trig
3.calc-fold-system
hw2 new-order
1. ouch-enter-order
2.boe-order-execution
3. boe-new-order-cross

hw3 trees
1.trees-avl
2. scapegoat-tree
3.trees-splay

hw4 caches
1.second-chance-multi-type

С 4 так грустно потому что мало начали делать её ещё.